### PR TITLE
Enable Linux compatibility

### DIFF
--- a/Arachneia-ScriptHost.pyw
+++ b/Arachneia-ScriptHost.pyw
@@ -16,7 +16,10 @@ icon_path = os.path.join(application_path, 'icons')
 scripts_path = os.path.join(application_path, 'scripts')
 Ver = "V0.8.1"
 
-sys.argv += ['-platform', 'windows:darkmode=2']
+# Use Windows dark mode setting only when running on Windows.
+if sys.platform.startswith("win"):
+    sys.argv += ['-platform', 'windows:darkmode=2']
+
 app = QApplication(sys.argv)
 
 def install_package(package_name):

--- a/README.md
+++ b/README.md
@@ -1,0 +1,17 @@
+# Arachneia Script Host
+
+This project hosts an interface for running helper scripts via PyQt5.
+
+## Running on Linux
+
+Install dependencies and run the main script with Python:
+
+```bash
+pip install PyQt5
+python3 Arachneia-ScriptHost.pyw
+```
+
+The application was originally targeted at Windows. The main script now checks the
+current platform before applying Windows-specific arguments so it can start on
+Linux as well.
+


### PR DESCRIPTION
## Summary
- fix Windows-specific argument handling
- add usage instructions for Linux

## Testing
- `python3 Arachneia-ScriptHost.pyw` *(fails: could not load the Qt platform plugin)*

------
https://chatgpt.com/codex/tasks/task_e_684140b67af0832faf3b7750bb340f13